### PR TITLE
Fix Id number

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 23
         versionCode 12
-        versionName "1.5.2"
+        versionName "1.5.3"
         vectorDrawables.useSupportLibrary = true
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'idea'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.3"
+    compileOptions.incremental = false /* incremental compile breaks ButterKnife */
     defaultConfig {
         applicationId "derpibooru.derpy"
         minSdkVersion 15

--- a/app/src/main/java/derpibooru/derpy/data/server/DerpibooruImageThumb.java
+++ b/app/src/main/java/derpibooru/derpy/data/server/DerpibooruImageThumb.java
@@ -7,7 +7,6 @@ import java.util.EnumSet;
 
 public class DerpibooruImageThumb implements Parcelable {
     private final int mId;
-    private final int mIdUsedForImageInteractions;
     private int mUpvotes;
     private int mDownvotes;
     private int mFaves;
@@ -19,16 +18,15 @@ public class DerpibooruImageThumb implements Parcelable {
     private final EnumSet<DerpibooruImageInteraction.InteractionType> mImageInteractions;
 
     public DerpibooruImageThumb(DerpibooruImageThumb from) {
-        this(from.getId(), from.getIdForImageInteractions(), from.getUpvotes(), from.getDownvotes(),
+        this(from.getId(), from.getUpvotes(), from.getDownvotes(),
              from.getFaves(), from.getCommentCount(), from.getThumbUrl(), from.getLargeImageUrl(),
              from.getSpoilerImageUrl(), from.getImageInteractions());
     }
 
-    public DerpibooruImageThumb(int id, int interactionsId, int upvotes, int downvotes, int faves,
+    public DerpibooruImageThumb(int id, int upvotes, int downvotes, int faves,
                                 int comments, String thumbUrl, String largeUrl, String spoilerImageUrl,
                                 EnumSet<DerpibooruImageInteraction.InteractionType> interactions) {
         mId = id;
-        mIdUsedForImageInteractions = interactionsId;
         mUpvotes = upvotes;
         mDownvotes = downvotes;
         mFaves = faves;
@@ -41,10 +39,6 @@ public class DerpibooruImageThumb implements Parcelable {
 
     public int getId() {
         return mId;
-    }
-
-    public int getIdForImageInteractions() {
-        return mIdUsedForImageInteractions;
     }
 
     public int getScore() {
@@ -109,7 +103,6 @@ public class DerpibooruImageThumb implements Parcelable {
 
     protected DerpibooruImageThumb(Parcel in) {
         mId = in.readInt();
-        mIdUsedForImageInteractions = in.readInt();
         mUpvotes = in.readInt();
         mDownvotes = in.readInt();
         mFaves = in.readInt();
@@ -128,7 +121,6 @@ public class DerpibooruImageThumb implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(mId);
-        dest.writeInt(mIdUsedForImageInteractions);
         dest.writeInt(mUpvotes);
         dest.writeInt(mDownvotes);
         dest.writeInt(mFaves);

--- a/app/src/main/java/derpibooru/derpy/server/parsers/ImageDetailedParser.java
+++ b/app/src/main/java/derpibooru/derpy/server/parsers/ImageDetailedParser.java
@@ -23,7 +23,6 @@ import derpibooru.derpy.server.parsers.objects.UserScriptParserObject;
 import derpibooru.derpy.server.parsers.objects.UserboxParserObject;
 
 public class ImageDetailedParser implements ServerResponseParser<DerpibooruImageDetailed> {
-    private static final Pattern PATTERN_IMAGE_ID = Pattern.compile("^(?:#)([\\d]*)");
     private static final Pattern PATTERN_WHITESPACE = Pattern.compile("\\s");
     private static final Pattern PATTERN_TAG_NUMBER_OF_IMAGES = Pattern.compile("(?!\\()([\\d*\\.]+)(?=\\))");
 
@@ -136,15 +135,14 @@ public class ImageDetailedParser implements ServerResponseParser<DerpibooruImage
     private DerpibooruImageThumb getImage(Document doc) throws JSONException {
         Element imageContainer = getImageContainer(doc);
 
-        int imageIdForInteractions = Integer.parseInt(imageContainer.attr("data-image-id"));
+        int imageId = Integer.parseInt(imageContainer.attr("data-image-id"));
         EnumSet interactions = EnumSet.noneOf(DerpibooruImageInteraction.InteractionType.class);
         if (mInteractions != null) {
-            interactions = mInteractions.getImageInteractionsForImage(imageIdForInteractions);
+            interactions = mInteractions.getImageInteractionsForImage(imageId);
         }
 
         DerpibooruImageThumb thumb = new DerpibooruImageThumb(
-                parseImageId(doc),
-                imageIdForInteractions,
+                imageId,
                 Integer.parseInt(imageContainer.attr("data-upvotes")),
                 Integer.parseInt(imageContainer.attr("data-downvotes")),
                 Integer.parseInt(imageContainer.attr("data-faves")),
@@ -158,12 +156,5 @@ public class ImageDetailedParser implements ServerResponseParser<DerpibooruImage
 
     private Element getImageContainer(Document doc) {
         return doc.select("div.image-show-container").first();
-    }
-
-    private int parseImageId(Document doc) {
-        String title = doc.select("title").first().text();
-        Matcher m = PATTERN_IMAGE_ID.matcher(title);
-        /* m.group(0) is '#000000', m.group(1) is '000000' */
-        return m.find() ? Integer.parseInt(m.group(1)) : 0;
     }
 }

--- a/app/src/main/java/derpibooru/derpy/server/parsers/ImageDetailedParser.java
+++ b/app/src/main/java/derpibooru/derpy/server/parsers/ImageDetailedParser.java
@@ -35,7 +35,7 @@ public class ImageDetailedParser implements ServerResponseParser<DerpibooruImage
         UserboxParserObject box = new UserboxParserObject(doc.select("div.userbox").first().html());
         if (box.isLoggedIn()) {
             UserScriptParserObject script =
-                    new UserScriptParserObject(doc.select("script").get(doc.select("script").size() - 2).html());
+                    new UserScriptParserObject(doc.select("body").select("script").last().html());
             mInteractions = new ImageInteractionsParserObject(script.getInteractions().toString());
         }
 

--- a/app/src/main/java/derpibooru/derpy/server/parsers/ImageListParser.java
+++ b/app/src/main/java/derpibooru/derpy/server/parsers/ImageListParser.java
@@ -45,7 +45,7 @@ public class ImageListParser implements ServerResponseParser<List<DerpibooruImag
         for (int x = 0; x < imgCount; x++) {
             JSONObject img = images.getJSONObject(x);
             DerpibooruImageThumb it = new DerpibooruImageThumb(
-                    img.getInt("id_number"), img.getInt("id"), img.getInt("upvotes"), img.getInt("downvotes"),
+                    img.getInt("id"), img.getInt("upvotes"), img.getInt("downvotes"),
                     img.getInt("faves"), img.getInt("comment_count"),
                     getAbsoluteUrl(img.getJSONObject("representations").getString("thumb")),
                     getAbsoluteUrl(img.getJSONObject("representations").getString("large")),

--- a/app/src/main/java/derpibooru/derpy/server/parsers/UserDataParser.java
+++ b/app/src/main/java/derpibooru/derpy/server/parsers/UserDataParser.java
@@ -18,16 +18,10 @@ public class UserDataParser implements ServerResponseParser<DerpibooruUser> {
     public DerpibooruUser parseResponse(String rawResponse) throws Exception {
         Document doc = Jsoup.parse(rawResponse);
         mUserbox = new UserboxParserObject(doc.select("div.userbox").first().html());
-        mUserScript = new UserScriptParserObject(getUserScript(doc).html());
+        mUserScript = new UserScriptParserObject(doc.select("body").select("script").last().html());
         return new DerpibooruUser(mUserScript.getUsername(), mUserScript.getAvatarUrl())
                 .setCurrentFilter(parseCurrentFilter());
     }
-
-    public Element getUserScript(Document doc) {
-        return mUserbox.isLoggedIn() ? doc.select("script").get(doc.select("script").size() - 2)
-                                     : doc.select("script").last();
-    }
-
     private DerpibooruFilter parseCurrentFilter() throws JSONException {
         return new DerpibooruFilter(mUserScript.getFilterId(), mUserbox.getFilterName(),
                                     mUserScript.getHiddenTagIds(), mUserScript.getSpoileredTagIds());

--- a/app/src/main/java/derpibooru/derpy/server/parsers/objects/ImageInteractionsParserObject.java
+++ b/app/src/main/java/derpibooru/derpy/server/parsers/objects/ImageInteractionsParserObject.java
@@ -37,17 +37,13 @@ public class ImageInteractionsParserObject {
             JSONObject interactionJson = mInteractions.getJSONObject(x);
             DerpibooruImageInteraction.InteractionType interaction =
                     getImageInteractionType(interactionJson);
-            int imageId = getImageIdForInteraction(interactionJson);
+            int imageId = interactionJson.getInt("image_id");
             if (!mInteractionsByImage.containsKey(imageId)) {
                 mInteractionsByImage.put(imageId, EnumSet.of(interaction));
             } else {
                 mInteractionsByImage.get(imageId).add(interaction);
             }
         }
-    }
-
-    private int getImageIdForInteraction(JSONObject interaction) throws JSONException {
-        return interaction.getInt("image_id");
     }
 
     @Nullable

--- a/app/src/main/java/derpibooru/derpy/server/requesters/ImageInteractionRequester.java
+++ b/app/src/main/java/derpibooru/derpy/server/requesters/ImageInteractionRequester.java
@@ -12,7 +12,7 @@ import derpibooru.derpy.server.parsers.ImageInteractionResultParser;
 public class ImageInteractionRequester extends AuthenticatedApiRequester<DerpibooruImageInteraction> {
     private DerpibooruImageInteraction.InteractionType mType;
     private String mApiKey;
-    private int mInteractionsImageId;
+    private int mImageId;
 
     public ImageInteractionRequester(Context context, QueryHandler<DerpibooruImageInteraction> handler) {
         super(context, handler);
@@ -24,14 +24,14 @@ public class ImageInteractionRequester extends AuthenticatedApiRequester<Derpibo
     }
 
     public ImageInteractionRequester onImage(int imageId) {
-        mInteractionsImageId = imageId;
+        mImageId = imageId;
         return this;
     }
 
     @Override
     protected Map<String, String> generateForm() {
         Map<String, String> form = new HashMap<>(3);
-        form.put("id", Integer.toString(mInteractionsImageId));
+        form.put("id", Integer.toString(mImageId));
         switch (mType) {
             case Fave:
                 form.put("value", "true");

--- a/app/src/main/java/derpibooru/derpy/ui/adapters/ImageListAdapter.java
+++ b/app/src/main/java/derpibooru/derpy/ui/adapters/ImageListAdapter.java
@@ -157,7 +157,7 @@ public abstract class ImageListAdapter extends RecyclerViewPaginationAdapter<Der
 
     private void initializeImageInteractions(final ViewHolder target, final int position) {
         target.interactions = new ImageInteractionPresenter(
-                getItems().get(position).getIdForImageInteractions(), target.buttonScore, target.buttonFave, target.buttonUpvote, null) {
+                getItems().get(position).getId(), target.buttonScore, target.buttonFave, target.buttonUpvote, null) {
             @NonNull
             @Override
             protected EnumSet<DerpibooruImageInteraction.InteractionType> getInteractionsSet() {

--- a/app/src/main/java/derpibooru/derpy/ui/presenters/ImageInteractionPresenter.java
+++ b/app/src/main/java/derpibooru/derpy/ui/presenters/ImageInteractionPresenter.java
@@ -24,12 +24,12 @@ public abstract class ImageInteractionPresenter {
     private AccentColorIconButton mUpvoteButton;
     private AccentColorIconButton mDownvoteButton;
 
-    protected ImageInteractionPresenter(int imageIdForInteractions,
+    protected ImageInteractionPresenter(int imageId,
                                         @Nullable AccentColorIconButton scoreButton,
                                         @Nullable AccentColorIconButton faveButton,
                                         @Nullable AccentColorIconButton upvoteButton,
                                         @Nullable AccentColorIconButton downvoteButton) {
-        mId = imageIdForInteractions;
+        mId = imageId;
         mScoreButton = scoreButton;
         mFaveButton = faveButton;
         mUpvoteButton = upvoteButton;

--- a/app/src/main/java/derpibooru/derpy/ui/views/imagedetailedview/ImageDetailedView.java
+++ b/app/src/main/java/derpibooru/derpy/ui/views/imagedetailedview/ImageDetailedView.java
@@ -112,7 +112,7 @@ public class ImageDetailedView extends LinearLayout {
     }
 
     private void initializeInteractionPresenter() {
-        int id = mCallbackHandler.getImage().getThumb().getIdForImageInteractions();
+        int id = mCallbackHandler.getImage().getThumb().getId();
         ImageInteractionPresenter presenter =
                 new ImageInteractionPresenter(id, topBar.buttonScore, bottomBar.buttonFave,
                                               topBar.buttonUpvote, topBar.buttonDownvote) {

--- a/app/src/test/java/derpibooru/derpy/server/parsers/ImageDetailedParserTest.java
+++ b/app/src/test/java/derpibooru/derpy/server/parsers/ImageDetailedParserTest.java
@@ -1,11 +1,8 @@
 package derpibooru.derpy.server.parsers;
 
-import com.google.common.collect.Lists;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -15,7 +12,6 @@ import derpibooru.derpy.data.server.DerpibooruImageDetailed;
 import derpibooru.derpy.data.server.DerpibooruImageInteraction;
 import derpibooru.derpy.data.server.DerpibooruImageThumb;
 import derpibooru.derpy.data.server.DerpibooruTag;
-import derpibooru.derpy.data.server.DerpibooruTagDetailed;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.beans.SamePropertyValuesAs.samePropertyValuesAs;
@@ -23,7 +19,7 @@ import static org.junit.Assert.assertThat;
 
 public class ImageDetailedParserTest {
     private static final DerpibooruImageThumb thumb =
-            new DerpibooruImageThumb(655777, 607986, 240, 3, 154, 32,
+            new DerpibooruImageThumb(655777, 240, 3, 154, 32,
                                      "https://derpicdn.net/img/2014/6/17/655777/thumb.gif",
                                      "https://derpicdn.net/img/2014/6/17/655777/large.gif", "",
                                      EnumSet.of(DerpibooruImageInteraction.InteractionType.Upvote,

--- a/app/src/test/java/derpibooru/derpy/server/parsers/ImageListParserTest.java
+++ b/app/src/test/java/derpibooru/derpy/server/parsers/ImageListParserTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThat;
 
 public class ImageListParserTest {
     private static final DerpibooruImageThumb firstImageThumb =
-            new DerpibooruImageThumb(960596, 960387, 3, 23, 1, 4,
+            new DerpibooruImageThumb(960596, 3, 23, 1, 4,
                                      "https://derpicdn.net/img/2015/8/18/960596/thumb.png",
                                      "https://derpicdn.net/img/2015/8/18/960596/large.png",
                                      "https://derpicdn.net/dummy_spoiler",

--- a/app/src/test/resources/SampleImageCommentsResponse.html
+++ b/app/src/test/resources/SampleImageCommentsResponse.html
@@ -1,4 +1,4 @@
-<div id="image_comments_607986">
+<div id="image_comments_655777">
     <div class="metabar meta-table">
         <div class="metasection">
             <div class="pagination">

--- a/app/src/test/resources/SampleImageDetailedLoggedOutResponse.html
+++ b/app/src/test/resources/SampleImageDetailedLoggedOutResponse.html
@@ -26,7 +26,7 @@
         </div>
     </div>
     <div id="content">
-        <div id="image_meta_607986">
+        <div id="image_meta_655777">
             <div class="metabar">
                 <div class="metasection hide-mobile-t" id="nav-links">
             <span class="prev"><a href="/prev/655777" title="Previous Image (j)">
@@ -43,7 +43,7 @@
             </span>
                 </div>
                 <div class="metasection">
-                    <a data-watch="607986" data-watch-class="Image" href="#">Subscribe</a>
+                    <a data-watch="655777" data-watch-class="Image" href="#">Subscribe</a>
                 </div>
                 <div class="metasection hide-mobile">
                     <a rel="nofollow" title="View this image at full res"
@@ -76,7 +76,7 @@
                  data-created-at="2014-06-17T22:32:45Z"
                  data-download-uri="//derpicdn.net/img/download/2014/6/17/655777.gif"
                  data-downvotes="3" data-faves="154" data-height="375" data-image-hidden="false"
-                 data-image-id="607986"
+                 data-image-id="655777"
                  data-image-tag-aliases="animated, animation, car, cars, don&#39;t trust wheels, epic fail, frown, gif, great and powerful trixie, israel, israeli army, lulamoon, palestine, safe, soldier, the great and powerful trixie, thought bubble, tire, trixie, trixie lulamoon, tx, upvotes galore, wheel, wheels, wide eyes"
                  data-image-tags="[54235,71149,98475,129438,988,22315,25454,26393,28087,31276,40482,42344,45242,45442,45912,47358]"
                  data-orig-sha512="ac0d00e645c1b0c8bace64ddec97c791629d36f171b121cb7b675ef985502bbd154df59c0b476ea36c24289e6cbe4e732cb754abf416d20b297cbbbf6049c4fe"
@@ -93,7 +93,7 @@
                 <h3 style="margin-top: 5px">Uploader Description </h3>Trixie has no one to blame but herself.
             </div>
         </div>
-        <div id="image_tags_and_source_607986">
+        <div id="image_tags_and_source_655777">
             <div class="tagsauce">
                 <div class="tag-list" style="margin-bottom:5px;">
                     <h6>Tags</h6>

--- a/app/src/test/resources/SampleImageDetailedResponse.html
+++ b/app/src/test/resources/SampleImageDetailedResponse.html
@@ -55,7 +55,7 @@
     </div>
     </div>
     <div id="content">
-        <div id="image_meta_607986">
+        <div id="image_meta_655777">
             <div class="metabar">
                 <div class="metasection hide-mobile-t" id="nav-links">
                     <span class="prev"><a href="/prev/655777" title="Previous Image (j)">
@@ -72,7 +72,7 @@
                     </span>
                 </div>
                 <div class="metasection">
-                   <a data-watch="607986" data-watch-class="Image" href="#">Subscribe</a>
+                   <a data-watch="655777" data-watch-class="Image" href="#">Subscribe</a>
                 </div>
                 <div class="metasection hide-mobile">
                     <a rel="nofollow" title="View this image at full res"
@@ -105,7 +105,7 @@
                  data-created-at="2014-06-17T22:32:45Z"
                  data-download-uri="//derpicdn.net/img/download/2014/6/17/655777.gif"
                  data-downvotes="3" data-faves="154" data-height="375" data-image-hidden="false"
-                 data-image-id="607986"
+                 data-image-id="655777"
                  data-image-tag-aliases="animated, animation, car, cars, don&#39;t trust wheels, epic fail, frown, gif, great and powerful trixie, israel, israeli army, lulamoon, palestine, safe, soldier, the great and powerful trixie, thought bubble, tire, trixie, trixie lulamoon, tx, upvotes galore, wheel, wheels, wide eyes"
                  data-image-tags="[54235,71149,98475,129438,988,22315,25454,26393,28087,31276,40482,42344,45242,45442,45912,47358]"
                  data-orig-sha512="ac0d00e645c1b0c8bace64ddec97c791629d36f171b121cb7b675ef985502bbd154df59c0b476ea36c24289e6cbe4e732cb754abf416d20b297cbbbf6049c4fe"
@@ -122,7 +122,7 @@
                 <h3 style="margin-top: 5px">Uploader Description </h3>Trixie has no one to blame but herself.
             </div>
         </div>
-        <div id="image_tags_and_source_607986">
+        <div id="image_tags_and_source_655777">
             <div class="tagsauce">
                 <div class="tag-list" style="margin-bottom:5px;">
                     <h6>Tags</h6>
@@ -198,13 +198,13 @@
                 "interaction_type": "voted",
                 "value": "up",
                 "user_id": 100000,
-                "image_id": 607986
+                "image_id": 655777
             }, {
                 "id": 1234,
                 "interaction_type": "faved",
                 "value": null,
                 "user_id": 100000,
-                "image_id": 607986
+                "image_id": 655777
             }];
             window.booru.enable_browser_ponies = false;
             // CDN root

--- a/app/src/test/resources/SampleImageListResponse.json
+++ b/app/src/test/resources/SampleImageListResponse.json
@@ -1,8 +1,7 @@
 {
     "search":[
         {
-            "id":"960387",
-            "id_number":960596,
+            "id":"960596",
             "created_at":"2015-08-18T22:31:34.194Z",
             "updated_at":"2016-01-14T06:00:09.3859Z",
             "duplicate_reports":[
@@ -50,8 +49,7 @@
             "is_optimized":true
         },
         {
-            "id":"960339",
-            "id_number":960548,
+            "id":"960548",
             "created_at":"2015-08-18T21:12:10.996Z",
             "updated_at":"2016-01-04T01:06:57.4862Z",
             "duplicate_reports":[
@@ -98,8 +96,7 @@
             "is_optimized":true
         },
         {
-            "id":"960271",
-            "id_number":960480,
+            "id":"960480",
             "created_at":"2015-08-18T19:59:55.308Z",
             "updated_at":"2016-02-02T23:45:16.6978Z",
             "duplicate_reports":[
@@ -147,8 +144,7 @@
             "is_optimized":true
         },
         {
-            "id":"956571",
-            "id_number":956780,
+            "id":"956780",
             "created_at":"2015-08-13T09:04:34.506Z",
             "updated_at":"2015-10-28T08:38:30.3081Z",
             "duplicate_reports":[
@@ -199,8 +195,7 @@
             "is_optimized":true
         },
         {
-            "id":"956418",
-            "id_number":956627,
+            "id":"956627",
             "created_at":"2015-08-13T03:32:27.609Z",
             "updated_at":"2015-10-22T14:36:06.2770Z",
             "duplicate_reports":[
@@ -245,8 +240,7 @@
             "is_optimized":true
         },
         {
-            "id":"956242",
-            "id_number":956451,
+            "id":"956451",
             "created_at":"2015-08-12T23:37:49.520Z",
             "updated_at":"2015-10-28T08:38:30.2581Z",
             "duplicate_reports":[
@@ -296,8 +290,7 @@
             "is_optimized":true
         },
         {
-            "id":"956136",
-            "id_number":956344,
+            "id":"956344",
             "created_at":"2015-08-12T21:29:52.789Z",
             "updated_at":"2015-10-22T14:39:05.5390Z",
             "duplicate_reports":[
@@ -346,8 +339,7 @@
             "is_optimized":true
         },
         {
-            "id":"956131",
-            "id_number":956339,
+            "id":"956339",
             "created_at":"2015-08-12T21:19:21.148Z",
             "updated_at":"2015-10-28T08:38:30.2219Z",
             "duplicate_reports":[
@@ -399,8 +391,7 @@
             "is_optimized":true
         },
         {
-            "id":"955637",
-            "id_number":955845,
+            "id":"955845",
             "created_at":"2015-08-12T01:39:59.188Z",
             "updated_at":"2015-12-18T00:43:48.8516Z",
             "duplicate_reports":[
@@ -453,8 +444,7 @@
             "is_optimized":true
         },
         {
-            "id":"955145",
-            "id_number":955353,
+            "id":"955353",
             "created_at":"2015-08-11T08:51:15.211Z",
             "updated_at":"2015-12-03T00:33:29.5258Z",
             "duplicate_reports":[
@@ -509,8 +499,7 @@
             "is_optimized":true
         },
         {
-            "id":"954331",
-            "id_number":954539,
+            "id":"954539",
             "created_at":"2015-08-09T23:09:25.073Z",
             "updated_at":"2016-02-05T19:13:10.7045Z",
             "duplicate_reports":[
@@ -560,8 +549,7 @@
             "is_optimized":true
         },
         {
-            "id":"954126",
-            "id_number":954334,
+            "id":"954334",
             "created_at":"2015-08-09T15:11:35.303Z",
             "updated_at":"2016-01-17T23:20:20.3933Z",
             "duplicate_reports":[
@@ -609,8 +597,7 @@
             "is_optimized":true
         },
         {
-            "id":"953859",
-            "id_number":954067,
+            "id":"954067",
             "created_at":"2015-08-09T04:55:21.295Z",
             "updated_at":"2016-02-02T09:12:12.9733Z",
             "duplicate_reports":[
@@ -662,8 +649,7 @@
             "is_optimized":true
         },
         {
-            "id":"953725",
-            "id_number":953933,
+            "id":"953933",
             "created_at":"2015-08-09T00:05:58.341Z",
             "updated_at":"2016-02-03T04:58:59.5408Z",
             "duplicate_reports":[
@@ -726,8 +712,7 @@
             "is_optimized":true
         },
         {
-            "id":"953702",
-            "id_number":953910,
+            "id":"953910",
             "created_at":"2015-08-08T23:07:04.268Z",
             "updated_at":"2016-01-24T15:27:28.6527Z",
             "duplicate_reports":[
@@ -797,14 +782,14 @@
             "interaction_type":"voted",
             "value":"down",
             "user_id":1,
-            "image_id":960387
+            "image_id":960596
         },
         {
             "id":1234,
             "interaction_type":"faved",
             "value":null,
             "user_id":1,
-            "image_id":960387
+            "image_id":960596
         }
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Recently, `id_number` has been dropped in favor of `id` for images. This pull request resolves incompatibilities between the application and the API that were introduced by the change.

In addition to that, I've fixed an issue where the application would crash on startup for logged-in users. Nasty.
